### PR TITLE
fixing broken link

### DIFF
--- a/distributed-map-csv-iterator-tf/example-workflow.json
+++ b/distributed-map-csv-iterator-tf/example-workflow.json
@@ -5,7 +5,7 @@
     "simplicity": "3 - Application",
     "usecase": "",
     "type": "Standard",
-    "diagram":"/resources/statemachine.png",
+    "diagram":"resources/statemachine.png",
     "videoId": "",
     "level": "300",
     "framework": "Terraform",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Fixing a broken link in the [distributed-map-csv-iterator-tf](https://github.com/aws-samples/step-functions-workflows-collection/tree/main/distributed-map-csv-iterator-tf) in the example-workflow.json file causing the state machine image not to display on the [Serverless Land Workflow Page](https://serverlessland.com/workflows/distributed-map-csv-iterator-tf)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
